### PR TITLE
upgrade rxjs and typescript versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@angular/platform-browser-dynamic": "4.0.0",
     "@angular/router": "4.0.0",
     "core-js": "2.4.1",
-    "rxjs": "5.1.0",
+    "rxjs": "5.4.3",
     "zone.js": "0.8.4",
     "ts-helpers": "1.1.1"
   },
@@ -50,6 +50,6 @@
     "protractor": "~5.1.0",
     "ts-node": "~2.0.0",
     "tslint": "~4.5.0",
-    "typescript": "~2.2.0"
+    "typescript": "~2.4.2"
   }
 }


### PR DESCRIPTION
after typescript 2.4.2, there introduced an error that was fixed in rxjs 5.4.3. see the error and issue here: https://github.com/ReactiveX/rxjs/issues/2705

ive upgraded the dependencies hoping to resolve this error. this repo is obsolte as of a couple months ago when this issue first arose. it will remain deprecated until you upgrade the versions. Hope you see this and accept my PR.